### PR TITLE
Update UIImageHandler.swift

### DIFF
--- a/ios/Classes/UIImageHandler.swift
+++ b/ios/Classes/UIImageHandler.swift
@@ -33,9 +33,9 @@ class UIImageHandler {
 
     func outputMemory(format: FormatOption) -> Data? {
         if format.format == 0 {
-            return UIImagePNGRepresentation(image)
+            return image.pngData()
         } else {
-            return UIImageJPEGRepresentation(image, CGFloat(format.quality) / 100)
+            return image.jpegData(compressionQuality: CGFloat(format.quality) / 100)
         }
     }
 


### PR DESCRIPTION
Fix error error: 'UIImagePNGRepresentation' has been replaced by instance method 'UIImage.pngData()' return UIImagePNGRepresentation(image) and error: 'UIImageJPEGRepresentation' has been replaced by instance method 'UIImage.jpegData(compressionQuality:)'  return UIImageJPEGRepresentation(image, CGFloat(format.quality) / 100)